### PR TITLE
added 404 for not found in execute blueprint

### DIFF
--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -430,6 +430,9 @@ async def executeBlueprint(request, blueprint, repository):
         j.atyourservice.server.logger.exception(error_msg)
         return json({'error': str(inputEx)}, 400)
 
+    except j.exceptions.NotFound as e:
+        return json({'error': str(e.message)}, 404)
+
     except Exception as e:
         error_msg = "Error during execution of the blueprint:\n %s" % str(e)
         j.atyourservice.server.logger.exception(error_msg)

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -431,7 +431,9 @@ async def executeBlueprint(request, blueprint, repository):
         return json({'error': str(inputEx)}, 400)
 
     except j.exceptions.NotFound as e:
-        return json({'error': str(e.message)}, 404)
+        error_msg = "Input Exception : \n %s" % str(e)        
+        j.atyourservice.server.logger.exception(error_msg)        
+        return json({'error': str(e.message)}, 400)
 
     except Exception as e:
         error_msg = "Error during execution of the blueprint:\n %s" % str(e)


### PR DESCRIPTION
#### What this PR resolves:
relates to https://github.com/zero-os/0-orchestrator/pull/483 and https://github.com/zero-os/0-orchestrator/issues/432

#### Changes proposed in this PR:

-added a handler for error not found to return a 404 status code and error message in the ays server 
-


**Version**: 

**Fixes**: #
