### PR TITLE
Remove g8core from ays9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def _post_install(libname, libpath):
 
     j.do.execute("pip3 install git+https://github.com/gigforks/PyInotify")
 
-    j.tools.jsloader.generateJumpscalePlugins()
+    j.tools.jsloader.generatePlugins()
     j.tools.jsloader.copyPyLibs()
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     install_requires=[
         'JumpScale9>=9.0.0',
         'JumpScale9Lib>=9.0.0',
-        'g8core>=1.0.0',  # is not ok, because strictly spoken this is not part of ays9
         'jsonschema>=2.6.0',
         'python-jose>=1.3.2',
         'sanic>=0.5.4'


### PR DESCRIPTION
#### What this PR resolves:
Remove reference to `g8core` which are not valid anymore and are not used at all on `ays9`