### PR TITLE
Fix executeblueprint api when the payload is empty

### DIFF
--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -457,7 +457,7 @@ async def executeBlueprint(request, blueprint, repository):
 
     try:
         inputs = request.json
-        message = inputs.get('message')
+        message = inputs.get('message') if inputs else None
         jobkeys = await repo.blueprintExecute(path=bp.path, context={'token': extract_token(request)},
                                               message=message)
 


### PR DESCRIPTION
#### What this PR resolves:
when the body of request was empty, AYS excuteBlueprint api gives error

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #
