### PR TITLE
#94 enable not to specify max services consumed by another 

### DIFF
--- a/JumpScale9AYS/ays/lib/Actor.py
+++ b/JumpScale9AYS/ays/lib/Actor.py
@@ -195,7 +195,7 @@ class Actor():
             self.model.producerAdd(
                 role=consume_info['role'],
                 min=int(consume_info['min']),
-                max=int(consume_info['max']),
+                max=int(consume_info.get('max', 0)),
                 auto=bool(consume_info['auto']),
                 argname=consume_info.get('argname', consume_info['role'])
             )

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -228,11 +228,11 @@ class Service:
 
             available_services = self.aysrepo.servicesFind(role=producer_role)
             available_services = list(set(available_services) - set(usersetservices))
-
-            extraservices = len(usersetservices) - producer_model.maxServices
-            if extraservices > 0:
-                raise j.exceptions.Input(message="Specified services [%s] are more than maximum services: [%s]" % (str(usersetservices), str(producer_model.maxServices)),
-                                         level=1, source="", tags="", msgpub="")
+            if producer_model.maxServices:
+                extraservices = len(usersetservices) - producer_model.maxServices
+                if extraservices > 0:
+                    raise j.exceptions.Input(message="Specified services [%s] are more than maximum services: [%s]" % (str(usersetservices), str(producer_model.maxServices)),
+                                             level=1, source="", tags="", msgpub="")
 
             tocreate = producer_model.minServices - len(available_services) - len(usersetservices)
             if tocreate > 0:

--- a/docs/Definitions/Producers-Consumers.md
+++ b/docs/Definitions/Producers-Consumers.md
@@ -23,6 +23,7 @@ links:
 
 This describes that the service consumes a minimum of `1` and a maximum of `100` sshkey instances, and that it should auto-create these instances if they don't already exist. Minimum and maximum tags are optional. As well as `auto`.
 
+Note that if you need the max services (consumed by a service) to be unlimited, either do not set the `max` attribute or set max to `0`
 
 
 ```toml


### PR DESCRIPTION
#### What this PR resolves:
Enable not to specify max services consumed by another service to be set to unlimited

#### Changes proposed in this PR:

- 
-


**Version**: 

**Fixes**: #
