### PR TITLE
remove service old parent info

### DIFF
--- a/JumpScale9AYS/ays/lib/models/ServiceModel.py
+++ b/JumpScale9AYS/ays/lib/models/ServiceModel.py
@@ -110,7 +110,7 @@ class ServiceModel(ActorServiceBaseModel):
 
         if service.parent == new_parent:
             return
-
+        old_parent_name = service.parent.name
         # remove old parent from the producers list.
         service.model.producerRemove(service.parent)
         # remove ourself from the consumers list of the old parent
@@ -148,6 +148,17 @@ class ServiceModel(ActorServiceBaseModel):
         service.model.reSerialize()
         service.parent.model.reSerialize()
         new_parent.model.reSerialize()
+        toRemove = None
+        for k, v in self.collection._db.dbindex.items():
+            if old_parent_name in k and service.name in k:
+                toRemove = k
+                break
+
+        if toRemove is not None:
+            self.collection._db.dbindex.pop(toRemove)
+
+        #import ipdb; ipdb.set_trace()
+        #self.collection._db.delete(self.key)
 
         self.save()
 

--- a/JumpScale9AYS/ays/lib/models/ServiceModel.py
+++ b/JumpScale9AYS/ays/lib/models/ServiceModel.py
@@ -2,7 +2,7 @@ from js9 import j
 from JumpScale9AYS.ays.lib.models.ActorServiceBaseModel import ActorServiceBaseModel
 from JumpScale9AYS.ays.lib.Service import Service
 from JumpScale9AYS.ays.lib import model_capnp as ModelCapnp
-import re
+
 VALID_STATES = ['new', 'installing', 'ok', 'error', 'disabled', 'changed']
 
 
@@ -151,12 +151,8 @@ class ServiceModel(ActorServiceBaseModel):
         service.parent.model.reSerialize()
         new_parent.model.reSerialize()
 
-        toRemoveItems = []
-        for k, v in self.collection._db.dbindex.items():
-            if re.match(old_parent_index, k) is not None:
-                toRemoveItems.append(k)
-
-        for toRemove in toRemoveItems:
+        toRemoveItems = self.collection._db.list(old_parent_index, True)
+        for (toRemove, key) in toRemoveItems:
             self.collection._db.dbindex.pop(toRemove)
 
         self.save()


### PR DESCRIPTION
#### What this PR resolves:
Removing old parent data form index


**Version**: 9.10

**Fixes**: #https://github.com/Jumpscale/ays9/issues/111
