### PR TITLE
trigger processChange on consumer remove link in delete

### DIFF
--- a/JumpScale9AYS/ays/AtYourServiceFactory.py
+++ b/JumpScale9AYS/ays/AtYourServiceFactory.py
@@ -25,7 +25,7 @@ class AtYourServiceFactory:
         self.debug = j.application.config['system']['debug']
         self.logger = j.logger.get('j.atyourservice.server')
         self.started = False
-
+        self.dev_mode = False
         self.baseActions = {}
         self.templateRepos = None
         self.aysRepos = None

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -383,8 +383,8 @@ class Service:
                 consumer.model.producerRemove(self)
                 consumer.model.reSerialize()
                 consumer.saveAll()
+                # here we trigger processChange with `links` category with args of removed producer role and name
                 consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producer_removed":linksargs})
-
 
         self.model.delete()
         j.sal.fs.removeDirTree(self.path)

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -357,6 +357,8 @@ class Service:
         @param force bool=False: will execute a dryrun to check if deleting this service won't break anything (force will remove children and consumption link with consumers even if minimum consumption isn't statisified after delete.
 
         """
+        linksargs = {'role': self.model.role, 'name':self.name}
+
         if not force:
             oktodelete, msg = await self.oktodelete()
             if not oktodelete:
@@ -381,8 +383,7 @@ class Service:
                 consumer.model.producerRemove(self)
                 consumer.model.reSerialize()
                 consumer.saveAll()
-                linksargs = {k:[v.name for v in v] for k,v in consumer.producers.items()}
-                consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producers":linksargs})
+                consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producer_removed":linksargs})
 
 
         self.model.delete()

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -357,7 +357,7 @@ class Service:
         @param force bool=False: will execute a dryrun to check if deleting this service won't break anything (force will remove children and consumption link with consumers even if minimum consumption isn't statisified after delete.
 
         """
-        linksargs = {'role': self.model.role, 'name':self.name}
+        producer_removed = "{}!{}".format(self.model.role, self.name)
 
         if not force:
             oktodelete, msg = await self.oktodelete()
@@ -384,7 +384,7 @@ class Service:
                 consumer.model.reSerialize()
                 consumer.saveAll()
                 # here we trigger processChange with `links` category with args of removed producer role and name
-                consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producer_removed":linksargs})
+                consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producer_removed":producer_removed})
 
         self.model.delete()
         j.sal.fs.removeDirTree(self.path)

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -1,6 +1,6 @@
-from js9 import j
-from JumpScale9AYS.ays.lib.Recurring import RecurringTask, LongRunningTask
 import asyncio
+from js9 import j
+from JumpScale9AYS.ays.lib.Recurring import LongRunningTask, RecurringTask
 
 
 class Service:
@@ -381,6 +381,9 @@ class Service:
                 consumer.model.producerRemove(self)
                 consumer.model.reSerialize()
                 consumer.saveAll()
+                linksargs = {k:[v.name for v in v] for k,v in consumer.producers.items()}
+                consumer.processChange(actor=self.aysrepo.actorGet(consumer.model.dbobj.actorName), changeCategory="links", args={"producers":linksargs})
+
 
         self.model.delete()
         j.sal.fs.removeDirTree(self.path)
@@ -541,6 +544,7 @@ class Service:
         template action change
         categories :
             - dataschema
+            - links
             - ui
             - config
             - action_new_actionname
@@ -552,7 +556,9 @@ class Service:
         if changeCategory == 'dataschema':
             # We use the args passed without change
             pass
-
+        elif changeCategory == 'links':
+            # used to trigger link update(prod/consumer, parent/child)
+            pass
         elif changeCategory == 'ui':
             # TODO
             pass

--- a/docs/Service-Lifecycle.md
+++ b/docs/Service-Lifecycle.md
@@ -80,7 +80,7 @@ setting `force = False` in `service.delete` will do a dryrun to see if you can d
 
 > it's always safer to use `force=False` and reason about your delete methods.
 
-> service.delete triggers processChange with `links` changeCategory and producer_removed key containing the removed producer name and role.
+> service.delete triggers processChange with `links` changeCategory and producer_removed key containing the removed producer `role!name`
 ### Default implementation for delete action
 It uses `j.tools.async.wrappers.sync(job.service.delete())` meaning `force=False` for safe deletions by default.
 

--- a/docs/Service-Lifecycle.md
+++ b/docs/Service-Lifecycle.md
@@ -80,6 +80,7 @@ setting `force = False` in `service.delete` will do a dryrun to see if you can d
 
 > it's always safer to use `force=False` and reason about your delete methods.
 
+> service.delete triggers processChange with `links` changeCategory and producer_removed key containing the removed producer name and role.
 ### Default implementation for delete action
 It uses `j.tools.async.wrappers.sync(job.service.delete())` meaning `force=False` for safe deletions by default.
 


### PR DESCRIPTION
#### What this PR resolves:
Fire processChange on service.delete to inform consumers about producers change (under category `links`)
