### PR TITLE
Remove async wrapper

### DIFF
--- a/JumpScale9AYS/ays/lib/Actor.py
+++ b/JumpScale9AYS/ays/lib/Actor.py
@@ -398,7 +398,7 @@ class Actor():
                                         amDecorator="actor", amMethodArgs="job", amDoc="")
 
                     elif actionname == "delete":
-                        amSource = "j.tools.async.wrappers.sync(job.service.delete())"
+                        amSource = "job.service.delete()"
                         self._addAction(actionName="delete", amSource=amSource,
                                         amDecorator="actor", amMethodArgs="job", amDoc="")
                     else:

--- a/JumpScale9AYS/ays/lib/Actor.py
+++ b/JumpScale9AYS/ays/lib/Actor.py
@@ -3,7 +3,7 @@ from .Service import Service
 from .utils import validate_service_name, Lock
 import capnp
 from JumpScale9AYS.ays.lib import model_capnp as ModelCapnp
-
+import asyncio
 
 class Actor():
 
@@ -515,7 +515,8 @@ class Actor():
         """
         same call as asyncServiceCreate but synchronous. we expose this so user can use this method in service actions.
         """
-        return j.tools.async.wrappers.sync(self.asyncServiceCreate(instance=instance, args=args, context=context))
+        futur = asyncio.run_coroutine_threadsafe(self.asyncServiceCreate(instance=instance, args=args, context=context), loop=self.aysrepo._loop)
+        return futur.result()
 
     @property
     def services(self):

--- a/JumpScale9AYS/ays/lib/Service.py
+++ b/JumpScale9AYS/ays/lib/Service.py
@@ -364,7 +364,11 @@ class Service:
                         return False, msg
         return True, "OK"
 
-    async def delete(self):
+    def delete(self):
+        futur = asyncio.run_coroutine_threadsafe(self.asyncDelete(), loop=self.aysrepo._loop)
+        return futur.result()
+
+    async def asyncDelete(self):
         """
         Deletes service and its children from database and filesystem if safe.
 
@@ -379,7 +383,7 @@ class Service:
         self._deleted = True
         if self.children:
             for service in self.children:
-                await service.delete()
+                await service.asyncDelete()
 
         # cancel all recurring tasks
         self.stop()
@@ -715,13 +719,17 @@ class Service:
 
         self.saveAll()
 
-    async def executeAction(self, action, args={}, context=None):
+    def executeAction(self, action, args={}, context=None):
         if action[-1] == "_":
-            return self.executeActionService(action)
+            return self._executeActionService(action)
         else:
-            return await self.executeActionJob(action, args, context=context)
+            futur = asyncio.run_coroutine_threadsafe(self.executeActionJob(action, args, context=context), loop=self.aysrepo._loop)
+            return futur.result()
 
-    def executeActionService(self, action, args={}):
+    def ayncExecuteAction(self, action, args={}, context=None):
+        return self.executeActionJob(action, args, context=context)
+
+    def _executeActionService(self, action, args={}):
         # execute an action in process without creating a job
         # usefull for methods called very often.
         action_id = self.model.actions[action].actionKey
@@ -733,7 +741,7 @@ class Service:
         res = eval(action)(service=self, args=args)
         return res
 
-    async def executeActionJob(self, actionName, args={}, context=None):
+    async def _executeActionJob(self, actionName, args={}, context=None):
         """
         creates a job and execute the action names actionName
         @param actionName: name of the action to execute

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -754,7 +754,7 @@ async def deleteServiceByName(request, name, role, repository):
         return json({'error': 'Service role:%s name:%s not found in the repo %s' % (role, name, repository)}, 404)
 
     try:
-        await service.delete()
+        await service.ayncDelete()
     except j.exceptions.RuntimeError as e:
         error_msg = "Error during deletion of service:\n %s" % str(e)
         j.atyourservice.server.logger.exception(error_msg)

--- a/docs/ActorTemplateFiles/Actions.md
+++ b/docs/ActorTemplateFiles/Actions.md
@@ -119,7 +119,7 @@ actions:
 
 In some situations you may want to be able to access the http request context of a request within an action.
 
-AYS allows you to access this context on the job object received in the service actions.  
+AYS allows you to access this context on the job object received in the service actions.
 
 For example, if you want to access the JWT token used to create a run:
 ```python
@@ -131,5 +131,5 @@ def install(job):
 
 In the case you create a job from within another job, make sure you pass the context around:
 ```python
-j.tools.async.wrappers.sync(service.executeAction('start', context=job.context))
+service.executeAction('start', context=job.context)
 ```

--- a/docs/Definitions/Services.md
+++ b/docs/Definitions/Services.md
@@ -155,4 +155,4 @@ def processChange(job):
 
 #### Default implementation for delete action
 
-If no `Delete(job)` action has been implemented `j.tools.async.wrappers.sync(job.service.delete())` will be used.
+If no `Delete(job)` action has been implemented `job.service.delete()` will be used.

--- a/templates/disk/disk.ovc/actions.py
+++ b/templates/disk/disk.ovc/actions.py
@@ -68,7 +68,7 @@ def processChange(job):
             if key not in ['size', 'type', 'description', 'devicename', 'ssdSize', 'g8client', 'location']:
                 setattr(service.model.data, key, value)
         if service.aysrepo.servicesFind(actor='node.ovc'):
-            j.tools.async.wrappers.sync(service.executeAction('limit_io'))
+            service.executeAction('limit_io')
 
 
 def limit_io(job):


### PR DESCRIPTION
MAKE SUR ALL TEST PASSES BEFORE MERGING THIS

#### What this PR resolves:
remove the need of using `j.tools.async.wrappers.sync` hack in the services actions

#### Changes proposed in this PR:

- make `Service.executeAction` not a coroutine
- add `Service.asyncExecuteAction
- make `Service.delete` not a coroutine
- add `Service.asyncDelete`