### PR TITLE
callback when run is finished

### DIFF
--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -272,8 +272,7 @@ async def createRun(request, repository):
             await repo.run_scheduler.add(run)
         if callback_url:
             run.callbackUrl = callback_url
-            data = {'runid': run.key, 'runState': run.state.__str__()}
-            requests.post(callback_url, headers={'Content-type': 'application/json'}, data=JSON.dumps(data))
+            run.save()
         return json(run_view(run), 200)
 
     except j.exceptions.Input as e:

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -247,6 +247,7 @@ async def listRuns(request, repository):
 
     return json(runs, 200)
 
+
 async def createRun(request, repository):
     '''
     Create a run based on all the action scheduled. This call returns an AYSRun object describing what is going to hapen on the repository.
@@ -270,12 +271,14 @@ async def createRun(request, repository):
         if not simulate:
             await repo.run_scheduler.add(run)
         if callback_url:
+            run.callbackUrl = callback_url
             data = {'runid': run.key, 'runState': run.state.__str__()}
             requests.post(callback_url, headers={'Content-type': 'application/json'}, data=JSON.dumps(data))
         return json(run_view(run), 200)
 
     except j.exceptions.Input as e:
         return json({'error': e.msgpub}, 500)
+
 
 async def getRun(request, aysrun, repository):
     '''

--- a/JumpScale9AYS/jobcontroller/Run.py
+++ b/JumpScale9AYS/jobcontroller/Run.py
@@ -1,6 +1,8 @@
 import colored_traceback
 from .RunStep import RunStep
 from js9 import j
+import requests
+import json
 
 colored_traceback.add_hook(always=True)
 
@@ -75,6 +77,14 @@ class Run:
                         out += str(action.result or '')
         return out
 
+    @property
+    def callbackUrl(self):
+        return self.model.dbobj.callbackUrl
+
+    @callbackUrl.setter
+    def callbackUrl(self, callbackUrl):
+        self.model.dbobj.callbackUrl = callbackUrl
+
     def reverse(self):
         ordered = []
         for i, _ in enumerate(self.model.dbobj.steps):
@@ -122,6 +132,10 @@ class Run:
             self.state = 'error'
             raise
         finally:
+            import ipdb; ipdb.set_trace()
+            if self.callbackUrl:
+                data = {'runid': self.key, 'runState': self.state.__str__()}
+                requests.post(self.callbackUrl, headers={'Content-type': 'application/json'}, data=json.dumps(data))
             self.save()
 
     def __repr__(self):

--- a/JumpScale9AYS/jobcontroller/Run.py
+++ b/JumpScale9AYS/jobcontroller/Run.py
@@ -132,7 +132,6 @@ class Run:
             self.state = 'error'
             raise
         finally:
-            import ipdb; ipdb.set_trace()
             if self.callbackUrl:
                 data = {'runid': self.key, 'runState': self.state.__str__()}
                 requests.post(self.callbackUrl, headers={'Content-type': 'application/json'}, data=json.dumps(data))

--- a/JumpScale9AYS/jobcontroller/models/model_job.capnp
+++ b/JumpScale9AYS/jobcontroller/models/model_job.capnp
@@ -217,4 +217,5 @@ struct Run {
 
     #key of repo where run is created
     repo @5 :Text;
+    callbackUrl @6 :Text;
 }

--- a/cmds/ays
+++ b/cmds/ays
@@ -493,14 +493,15 @@ def _print_run(run, logs=False):
 @click.option('--debug', default=False, is_flag=True, help='enable debug in jobs')
 @click.option('--profile', default=False, is_flag=True, help='enable profiling of the jobs')
 @click.option('--follow', '-f', is_flag=True, help='follow run execution')
-def create(assume_yes, force, debug, profile, follow):
+@click.option('--callback', '-c', default=None, help='callbackUrl to which run state will be sent after the run is finished')
+def create(assume_yes, force, debug, profile, follow, callback):
     """
     Look for all action with a state 'schedule', 'changed' or 'error' and create a run.
     A run is an collection of actions that will be run on the repository.
     """
     print("Creation of the run...")
     try:
-        resp = ayscl.api.ays.createRun(data=None, repository=_current_repo_name(), query_params={'simulate': True})
+        resp = ayscl.api.ays.createRun(data=None, repository=_current_repo_name(), query_params={'simulate': True, 'callback_url': callback})
     except Exception as e:
         print("Error during creation of the run: {}".format(_extract_error(e)))
         return

--- a/docs/Commands/run/create.md
+++ b/docs/Commands/run/create.md
@@ -1,5 +1,6 @@
 # ays run create
 
+
 ```shell
 ays run create --help
 Usage: ays run create [OPTIONS]
@@ -9,14 +10,21 @@ Usage: ays run create [OPTIONS]
   repository.
 
 Options:
-  -y, --yes, --asume-yes  Automatic yes to prompts. Assume "yes" as answer to
-                        all prompts and run non-interactively
-  --force       force execution even if no change
-  --debug       enable debug in jobs
-  --profile     enable profiling of the jobs
-  -f, --follow  follow run execution
-  --help        Show this message and exit.
+  -y, --yes, --assume-yes  Automatic yes to prompts. Assume "yes" as answer to
+                           all prompts and run non-interactively
+  --force                  force execution even if no change
+  --debug                  enable debug in jobs
+  --profile                enable profiling of the jobs
+  -f, --follow             follow run execution
+  -c, --callback TEXT      callbackUrl to which run state will be sent after
+                           the run is finished
+  --help                   Show this message and exit.
+
 ```
+
+## Callback url
+
+The url specified in this option will be used to send the state information of the run. A post request will be sent to the url containing the run id and the run state after the run has either failed or succeeded.
 
 ```toml
 !!!


### PR DESCRIPTION
#### What this PR resolves:
Data is sent to callback url when the run is finished.

#### Changes proposed in this PR:

- If callback url is specified, the runid and state will be sent to the url



**Version**: 9.1.1

**Relates to**: #https://github.com/Jumpscale/ays9/issues/208
