### PR TITLE
fix g8osfs install action

### DIFF
--- a/templates/fs/fs.g8osfs/actions.py
+++ b/templates/fs/fs.g8osfs/actions.py
@@ -87,7 +87,7 @@ def install(job):
     pm = prefab.processmanager.get('tmux')
     bin_location = prefab.core.command_location('fs')
     cmd = '%s -config %s' % (bin_location, config_path)
-    pm.ensure("fs_%s" % service.name, cmd=cmd, env={}, path='$JSCFGDIR/fs', descr='G8OS FS', autostart=True, wait="3m")
+    pm.ensure("fs_%s" % service.name, cmd=cmd, env={}, path='$JSCFGDIR/fs', descr='G8OS FS', autostart=True, wait=180)
 
     # wait until all targets are actually mounted
     # We wait max 1 min per target


### PR DESCRIPTION
#### What this PR resolves:
Changed the 3m string to be 180 to avoid error at prefab tmux execute: https://github.com/Jumpscale/prefab9/blob/master/JumpScale9Prefab/PrefabTmux.py#L126

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #232
