### PR TITLE
hardening account template usage

### DIFF
--- a/templates/ovc/account/README.md
+++ b/templates/ovc/account/README.md
@@ -39,6 +39,9 @@ Use the accountusers parameter to specify the user access right to the account. 
 
 Note that the data in the blueprint is always reflected in the account, which means that removing an entry in the blueprint will remove or change it in the account. If the user only wants to edit some data then it is possible to do so by using processChange action.
 
+>This is especially relevant to the account template because it is possible to remove the user who created the account(which might be the g8client), so it is very important to reflect that in the blueprint with correct access rights. The original user can be removed if another user with admin access is specified in the blueprint.
+This means that unlike node and vdc templates if no users are sepcified, there would be no change to the account access, so for example if it is required to remove all access except the owner, the owner needs to be specified in the users list.
+
 It is possible to add, remove and update user access to the account. To add a user after creating the account, a new uservdc has to be added in the blueprint. Executing the blueprint will trigger the process change and add it to the account. In the same way a user can be removed from the account by deleting the entry from the accountusers in the blueprint. Changing the accesstype of as user will update the user access to the account when executing the blueprint and as above removing it will change the access right to the default value `ACDRUX`.
 
 ## Access rights

--- a/templates/ovc/account/actions.py
+++ b/templates/ovc/account/actions.py
@@ -26,6 +26,8 @@ def authorization_user(account, service):
     authorized_users = account.authorized_users
 
     userslist = service.producers.get('uservdc', [])
+    if not userslist:
+        return
     users = []
     user_exists = True
     for u in userslist:


### PR DESCRIPTION
#### What this PR resolves:
Improving account template usage, so that no change to authorized users is triggered when no users are specified in the blueprint.
