### PR TITLE
fix for failed recurring jobs

### DIFF
--- a/JumpScale9AYS/ays/lib/Recurring.py
+++ b/JumpScale9AYS/ays/lib/Recurring.py
@@ -31,8 +31,10 @@ class RecurringTask:
                 await asyncio.sleep(sleep)
 
                 # execute
-                await self._job.execute()
-
+                try:
+                    await self._job.execute()
+                except:
+                    pass
                 # update last exection time
                 action_info.lastRun = j.data.time.epoch
 


### PR DESCRIPTION
#### What this PR resolves:
Recurring jobs don't stop when an error is raised.

