### PR TITLE
install finishes after vdc is deployed

### DIFF
--- a/templates/ovc/vdc/actions.py
+++ b/templates/ovc/vdc/actions.py
@@ -73,6 +73,7 @@ def authorization_user(space, service):
 
 
 def install(job):
+    import time
     service = job.service
     if 'g8client' not in service.producers:
         raise j.exceptions.AYSNotFound("No producer g8client found. Cannot continue install of %s" % service)
@@ -107,6 +108,11 @@ def install(job):
     space.model['maxCPUCapacity'] = service.model.data.maxCPUCapacity
     space.model['maxNetworkPeerTransfer'] = service.model.data.maxNetworkPeerTransfer
     space.save()
+
+    status = space.model['status']
+    while status != 'DEPLOYED':
+        time.sleep(5)
+        status = cl.api.cloudapi.cloudspaces.get(cloudspaceId=service.model.data.cloudspaceID)['status']
 
 
 def get_user_accessright(username, service):

--- a/templates/ovc/vdc/actions.py
+++ b/templates/ovc/vdc/actions.py
@@ -110,9 +110,14 @@ def install(job):
     space.save()
 
     status = space.model['status']
-    while status != 'DEPLOYED':
+    timeout_limit = time.time() + 60
+    while time.time() < timeout_limit:
+        if status == 'DEPLOYED':
+            break
         time.sleep(5)
         status = cl.api.cloudapi.cloudspaces.get(cloudspaceId=service.model.data.cloudspaceID)['status']
+    else:
+        raise j.exceptions.Timeout("VDC not yet deployed")
 
 
 def get_user_accessright(username, service):


### PR DESCRIPTION
#### What this PR resolves:

VDC install action waits for the cloudspace to be deployed before it finishes to prevent actions on a cloudspace while it is still deploying.

**Version**: 9.1.2

**Fixes**: #https://github.com/Jumpscale/ays9/issues/271
