### PR TITLE
allow configuration to run scheduler

### DIFF
--- a/JumpScale9AYS/ays/lib/AtYourServiceRepo.py
+++ b/JumpScale9AYS/ays/lib/AtYourServiceRepo.py
@@ -647,6 +647,7 @@ class AtYourServiceRepo():
                 job.model.dbobj.profile = profile
                 job.model.dbobj.debug = profile if profile is True else debug
                 job.model.dbobj.tags = jobs_tags if jobs_tags else []
+                job.model.dbobj.runKey = run.model.key
                 if context is not None:
                     for k, v in context.items():
                         job.context[k] = v

--- a/JumpScale9AYS/ays/lib/RunScheduler.py
+++ b/JumpScale9AYS/ays/lib/RunScheduler.py
@@ -31,11 +31,11 @@ class RunScheduler:
         @param retry_config: list containing the delay values.
         """
         retry_delay = {}
-        if retries[0] != '0':
+        if retries[0] != 0:
             for idx, value in enumerate(retries):
                 if value == '0':
                     raise j.exceptions.Input("Retry delay value can't be 0")
-                retry_delay[idx + 1] = int(value)
+                retry_delay[idx + 1] = value
         return retry_delay
 
     @property

--- a/JumpScale9AYS/ays/server/apidocs/api.raml
+++ b/JumpScale9AYS/ays/server/apidocs/api.raml
@@ -722,6 +722,9 @@ types:
               callback_url:
                 description: URL where to send the result of the run once executed
                 type: string
+              retries:
+                description: Configures the run scheduler to change number of retries and delay values
+                type: string
             responses:
               200:
                 body:

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -274,18 +274,22 @@ async def createRun(request, repository):
     Create a run based on all the action scheduled. This call returns an AYSRun object describing what is going to hapen on the repository.
     This is an asyncronous call. To be notify of the status of the run when then execution is finised or when an error occurs, you need to specify a callback url.
     A post request will be send to this callback url with the status of the run and the key of the run. Using this key you can inspect in detail the result of the run
-    using the 'GET /ays/repository/{repository}/aysrun/{aysrun_key}' endpoint
+    using the 'GET /ays/repository/{repository}/aysrun/{aysrun_key}' endpoint.
+    By specifying the retries as a string of comma seperated values it is possible to configure the retry delay of the run scheduler,
+    with the number of retries being the number of specified values. For no retries send a string with only 0.
     It is handler for POST /ays/repository/<repository>/aysrun
     '''
-    import requests
     try:
         repo = get_repo(repository)
     except j.exceptions.NotFound as e:
         return json({'error': e.message}, 404)
     simulate = j.data.types.bool.fromString(request.args.get('simulate', 'False'))
     callback_url = request.args.get('callback_url', None)
-
+    retries = request.args.get('retries', None)
     try:
+        if retries:
+            retries = retries.split(",")
+            repo.run_scheduler.configure_retry_delay(retries)
         to_execute = repo.findScheduledActions()
         run = repo.runCreate(to_execute, context={"token": extract_token(request)})
         run.save()

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -287,12 +287,13 @@ async def createRun(request, repository):
     callback_url = request.args.get('callback_url', None)
     retries = request.args.get('retries', None)
     try:
-        if retries:
-            retries = retries.split(",")
-            repo.run_scheduler.configure_retry_delay(retries)
         to_execute = repo.findScheduledActions()
         run = repo.runCreate(to_execute, context={"token": extract_token(request)})
         run.save()
+        if retries:
+            retries = retries.split(",")
+            run.retries = retries
+            run.save()
         if not simulate:
             await repo.run_scheduler.add(run)
         if callback_url:

--- a/JumpScale9AYS/ays/server/ays_api.py
+++ b/JumpScale9AYS/ays/server/ays_api.py
@@ -291,7 +291,7 @@ async def createRun(request, repository):
         run = repo.runCreate(to_execute, context={"token": extract_token(request)})
         run.save()
         if retries:
-            retries = retries.split(",")
+            retries = [int(x) for x in retries.split(',')]
             run.retries = retries
             run.save()
         if not simulate:
@@ -303,6 +303,8 @@ async def createRun(request, repository):
 
     except j.exceptions.Input as e:
         return json({'error': e.msgpub}, 500)
+    except ValueError:
+        return json({'error': 'Only numbers allowed for retry config'}, 400)
 
 
 async def getRun(request, aysrun, repository):

--- a/JumpScale9AYS/ays/server/views.py
+++ b/JumpScale9AYS/ays/server/views.py
@@ -96,16 +96,7 @@ def run_view(run):
                 'result': job.model.dbobj.result
             })
         obj['steps'].append(aystep)
-    retry = run.get_retry_level()
-    obj['retries'] = {}
-    if retry:
-        if run.retries[0] != '0':
-            remaining_retries = [x for x in run.retries]
-            obj['retries'] = {
-                'retry-number': retry,
-                'duration': run.retries[retry - 1],
-                'remaining-retries': remaining_retries[retry:]
-            }
+    obj['retries'] = run.get_retry_info()
 
     return obj
 

--- a/JumpScale9AYS/ays/server/views.py
+++ b/JumpScale9AYS/ays/server/views.py
@@ -96,15 +96,15 @@ def run_view(run):
                 'result': job.model.dbobj.result
             })
         obj['steps'].append(aystep)
-    retry = run.aysrepo.run_scheduler.get_retry_level(run)
+    retry = run.get_retry_level()
     obj['retries'] = {}
     if retry:
-        run_retries = list(run.aysrepo.run_scheduler.retry_config.values())
-        if run_retries:
+        if run.retries[0] != '0':
+            remaining_retries = [x for x in run.retries]
             obj['retries'] = {
                 'retry-number': retry,
-                'duration': run_retries[retry - 1],
-                'remaining-retries': run_retries[retry:]
+                'duration': run.retries[retry - 1],
+                'remaining-retries': remaining_retries[retry:]
             }
 
     return obj

--- a/JumpScale9AYS/jobcontroller/Job.py
+++ b/JumpScale9AYS/jobcontroller/Job.py
@@ -53,9 +53,11 @@ def _execute_cb(job, future):
         if service_action_obj:
             service_action_obj.state = 'error'
             # make sure we don't keep increasing this number forever, it could overflow.
-            repo = j.atyourservice.server.aysRepos.get(path=job.model.dbobj.repoKey)
-            if service_action_obj.errorNr < len(repo.run_scheduler.retry_config) + 1:
-                service_action_obj.errorNr += 1
+            if job.model.dbobj.runKey:
+                run = j.core.jobcontroller.db.runs.get(job.model.dbobj.runKey)
+                run = run.objectGet()
+                if service_action_obj.errorNr < len(run.retries) + 1:
+                    service_action_obj.errorNr += 1
             job.service.model.dbobj.state = 'error'
 
         ex = exception if exception is not None else TimeoutError()

--- a/JumpScale9AYS/jobcontroller/Job.py
+++ b/JumpScale9AYS/jobcontroller/Job.py
@@ -45,7 +45,6 @@ def _execute_cb(job, future):
         exception = err
         job.logger.info("{} has been cancelled".format(job))
 
-
     if exception is not None:
         # state state of job and run to error
         # this state will be check by RunStep and Run and it will raise an exception
@@ -54,7 +53,8 @@ def _execute_cb(job, future):
         if service_action_obj:
             service_action_obj.state = 'error'
             # make sure we don't keep increasing this number forever, it could overflow.
-            if service_action_obj.errorNr < 5:
+            repo = j.atyourservice.server.aysRepos.get(path=job.model.dbobj.repoKey)
+            if service_action_obj.errorNr < len(repo.run_scheduler.retry_config) + 1:
                 service_action_obj.errorNr += 1
             job.service.model.dbobj.state = 'error'
 

--- a/JumpScale9AYS/jobcontroller/Run.py
+++ b/JumpScale9AYS/jobcontroller/Run.py
@@ -4,7 +4,7 @@ from js9 import j
 import json
 import aiohttp
 colored_traceback.add_hook(always=True)
-RETRY_DELAY = ['10', '30', '60', '300', '600', '1800']  # time of each retry in seconds, total: 46min 10sec
+RETRY_DELAY = [10, 30, 60, 300, 600, 1800]  # time of each retry in seconds, total: 46min 10sec
 
 
 class Run:
@@ -83,7 +83,7 @@ class Run:
     def get_retry_info(self):
         runInfo = {}
         retry = self.get_retry_level()
-        if retry and self.retries[0] != '0' and retry <= len(self.retries):
+        if retry and self.retries[0] != 0 and retry <= len(self.retries):
             # capnp list to python list
             remaining_retries = [x for x in self.retries]
             runInfo = {

--- a/JumpScale9AYS/jobcontroller/models/model_job.capnp
+++ b/JumpScale9AYS/jobcontroller/models/model_job.capnp
@@ -220,4 +220,5 @@ struct Run {
     #key of repo where run is created
     repo @5 :Text;
     callbackUrl @6 :Text;
+    retries @7 :List(Text);
 }

--- a/JumpScale9AYS/jobcontroller/models/model_job.capnp
+++ b/JumpScale9AYS/jobcontroller/models/model_job.capnp
@@ -1,4 +1,4 @@
-@0xb6d407bcbd7a90e0;
+@0xb52807b3b9c13fc8;
 
 
 struct Command {

--- a/JumpScale9AYS/jobcontroller/models/model_job.capnp
+++ b/JumpScale9AYS/jobcontroller/models/model_job.capnp
@@ -1,4 +1,4 @@
-@0xb52807b3b9c13fc8;
+@0xf16088fb1cfdee20;
 
 
 struct Command {
@@ -220,5 +220,5 @@ struct Run {
     #key of repo where run is created
     repo @5 :Text;
     callbackUrl @6 :Text;
-    retries @7 :List(Text);
+    retries @7 :List(UInt32);
 }

--- a/cmds/ays
+++ b/cmds/ays
@@ -494,14 +494,15 @@ def _print_run(run, logs=False):
 @click.option('--profile', default=False, is_flag=True, help='enable profiling of the jobs')
 @click.option('--follow', '-f', is_flag=True, help='follow run execution')
 @click.option('--callback', '-c', default=None, help='callbackUrl to which run state will be sent after the run is finished')
-def create(assume_yes, force, debug, profile, follow, callback):
+@click.option('--retries', '-r', default=None, help='Configuration for run scheduler as comma separated values')
+def create(assume_yes, force, debug, profile, follow, callback, retries):
     """
     Look for all action with a state 'schedule', 'changed' or 'error' and create a run.
     A run is an collection of actions that will be run on the repository.
     """
     print("Creation of the run...")
     try:
-        resp = ayscl.api.ays.createRun(data=None, repository=_current_repo_name(), query_params={'simulate': True, 'callback_url': callback})
+        resp = ayscl.api.ays.createRun(data=None, repository=_current_repo_name(), query_params={'simulate': True, 'callback_url': callback, 'retries': retries})
     except Exception as e:
         print("Error during creation of the run: {}".format(_extract_error(e)))
         return

--- a/docs/Commands/run/create.md
+++ b/docs/Commands/run/create.md
@@ -18,13 +18,28 @@ Options:
   -f, --follow             follow run execution
   -c, --callback TEXT      callbackUrl to which run state will be sent after
                            the run is finished
+  -r, --retries TEXT       Configuration for run scheduler as comma separated
+                           values
   --help                   Show this message and exit.
-
 ```
 
 ## Callback url
 
 The url specified in this option will be used to send the state information of the run. A post request will be sent to the url containing the run id and the run state after the run has either failed or succeeded.
+
+## Retries Configuration
+
+The values specified using this option will be configure the delays of the run scheduler as well as the number of retries for that specific run. The number of retries will depend on the number of values specified. If the option is not specified it will use the default configuration see run [docs](../../Definitions/Runs.md). An example configuration which will set the number of retries to 4:
+
+```shell
+ays run create --retries 10,30,60,120
+```
+
+To prevent retries altogether:
+
+```shell
+ays run create --retries 0
+```
 
 ```toml
 !!!

--- a/docs/Definitions/Runs.md
+++ b/docs/Definitions/Runs.md
@@ -20,7 +20,19 @@ Also, when some of the jobs in a run fail, we don't want that to create a deadlo
 The solution used in AYS is to use a queue. So everytime a user ask for a run to execute, this requests is pushed to a queue. Then a the requests are extracted from the queue and processed sequentially. This creates a uniq point of execution for all the runs and thus ensures we always only have one running at the same time.
 
 - **Retries failed jobs:**  
-When a job fails in a run, this jobs is then reintroduced in the execution loop. We retry to execute the job 6 times in total with a growing delay between the tries.
+When a job fails in a run, this jobs is then reintroduced in the execution loop. By default we retry to execute the job 6 times in total with a growing delay between the tries. The default delay values are:
+```
+10 sec
+30 sec
+1 min
+5 min
+10 min
+30 min
+```
+
+For a total of 46min 10sec.
+
+It is possible to configure the number of retries and the delay between them when creating a run. The values of the delays are specified in a string separated by a comma, with the number of retries being the number of values. It can be configured to prevent retries if specified.
 
 
 See the full execution model in the following schema:

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
         'JumpScale9Lib>=9.1.2',
         'jsonschema>=2.6.0',
         'python-jose==1.3.2',
-        'sanic>=0.5.4'
+        'sanic>=0.5.4',
+        'aiohttp>=2.2.5'
     ],
     cmdclass={
         'install': install,


### PR DESCRIPTION
#### What this PR resolves:
Configuring the number of retries and their delays duration.

#### Changes proposed in this PR:

- It is possible to configure the run scheduler during the creation of a run



**Version**: 9.2.0

**Fixes**: https://github.com/Jumpscale/ays9/issues/267
