### PR TITLE
allow multiple consumption for same actor role

### DIFF
--- a/JumpScale9AYS/ays/lib/models/ActorModel.py
+++ b/JumpScale9AYS/ays/lib/models/ActorModel.py
@@ -76,8 +76,7 @@ class ActorModel(ActorServiceBaseModel):
         """
         o = self.collection.capnp_schema.ActorPointer.new_message(actorRole=role, minServices=int(min), maxServices=int(max),
                                                         auto=bool(auto), optional=bool(optional), argname=argname)
-        self.updateSubItem('producers', keys='actorRole', data=o)
-
+        self.updateSubItem('producers', keys=['actorRole', 'argname'], data=o)
 
     @property
     def dictFiltered(self):


### PR DESCRIPTION
#### Changes proposed in this PR:

- By specifying `argname` in the `config.yaml` it is possible to have multiple producers of the same role.



**Version**: 9.2.0

**Fixes**: https://github.com/Jumpscale/ays9/issues/332
